### PR TITLE
Fix: 대회일정 카드 포스터 그림자 튀어나옴 수정

### DIFF
--- a/najuha-fronted/src/components/competitionlist.css
+++ b/najuha-fronted/src/components/competitionlist.css
@@ -310,6 +310,7 @@
   height: 100%;
   top: 0;
   bottom: 0;
+  border-radius: 10px 0 0 10px;
   z-index: 1;
 }
 


### PR DESCRIPTION
로컬에서는 그림자 안튀어나오게 잘 되는데, 빌드해서 실제 서버에서는 튀어나옴.

기존 overflow: hidden; 으로 막았는데 그냥 그림자 자체에 border-radius를 줘서 버그 원천봉쇄!